### PR TITLE
Add UI-TARS configuration inputs

### DIFF
--- a/computer_use_demo/loop.py
+++ b/computer_use_demo/loop.py
@@ -66,7 +66,8 @@ def sampling_loop_sync(
     selected_screen: int = 0,
     showui_max_pixels: int = 1344,
     showui_awq_4bit: bool = False,
-    ui_tars_url: str = ""
+    ui_tars_url: str = "",
+    ui_tars_api_key: str = ""
 ):
     """
     Synchronous agentic sampling loop for the assistant/tool interaction of computer use.
@@ -200,6 +201,7 @@ def sampling_loop_sync(
         actor = UITARS_Actor(
             ui_tars_url=ui_tars_url,
             output_callback=output_callback,
+            api_key=ui_tars_api_key,
             selected_screen=selected_screen
         )
         


### PR DESCRIPTION
## Summary
- add UI-TARS URL and API key fields to the Gradio settings panel and persist their values in state
- pass the configured UI-TARS endpoint and key through the sampling loop to the UITARS actor

## Testing
- python -m compileall app.py computer_use_demo/loop.py computer_use_demo/gui_agent/actor/uitars_agent.py

------
https://chatgpt.com/codex/tasks/task_b_68e2948b3f488325983c9bddd2216faf