### PR TITLE
Handle UI-TARS absolute coordinates in ShowUIExecutor

### DIFF
--- a/computer_use_demo/gui_agent/actor/uitars_agent.py
+++ b/computer_use_demo/gui_agent/actor/uitars_agent.py
@@ -108,7 +108,8 @@ def convert_ui_tars_action_to_json(action_str: str) -> str:
     output_dict = {
         "action": None,
         "value": None,
-        "position": None
+        "position": None,
+        "position_source": "ui-tars",
     }
 
     # 1) CLICK(...) e.g. click(start_box='(153,97)')
@@ -117,6 +118,7 @@ def convert_ui_tars_action_to_json(action_str: str) -> str:
         x, y = match_click.groups()
         output_dict["action"] = ACTION_MAP["click"]
         output_dict["position"] = [int(x), int(y)]
+        output_dict["position_mode"] = "absolute"
         return json.dumps(output_dict)
 
     # 2) HOTKEY(...) e.g. hotkey(key='Enter')


### PR DESCRIPTION
## Summary
- detect absolute coordinate payloads in the ShowUI executor and avoid scaling while applying screen offsets when needed
- tag UI-TARS click actions with absolute coordinate metadata for downstream consumers
- expand unit coverage to verify coordinate handling for ShowUI and UI-TARS sources

## Testing
- pytest tests/test_showui_executor.py

------
https://chatgpt.com/codex/tasks/task_b_68e29cfc41048325a6b97c335366247a