### PR TITLE
feat: add Gemini API planner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ If you successfully start the interface, you will see two URLs in the terminal:
 > $env:ANTHROPIC_API_KEY="sk-xxxxx" (Replace with your own key)
 > $env:QWEN_API_KEY="sk-xxxxx"
 > $env:OPENAI_API_KEY="sk-xxxxx"
+> $env:GEMINI_API_KEY="sk-xxxxx"
 > ```
 > On macOS/Linux, replace `$env:ANTHROPIC_API_KEY` with `export ANTHROPIC_API_KEY` in the above command. 
 

--- a/app.py
+++ b/app.py
@@ -51,16 +51,20 @@ def setup_state(state):
         state["actor_model"] = "ShowUI"    # default
     if "planner_provider" not in state:
         state["planner_provider"] = "openai"  # default
+    if "planner_api_provider" not in state:
+        state["planner_api_provider"] = state["planner_provider"]
     if "actor_provider" not in state:
         state["actor_provider"] = "local"    # default
 
-     # Fetch API keys from environment variables
-    if "openai_api_key" not in state: 
+    # Fetch API keys from environment variables
+    if "openai_api_key" not in state:
         state["openai_api_key"] = os.getenv("OPENAI_API_KEY", "")
     if "anthropic_api_key" not in state:
-        state["anthropic_api_key"] = os.getenv("ANTHROPIC_API_KEY", "")    
+        state["anthropic_api_key"] = os.getenv("ANTHROPIC_API_KEY", "")
     if "qwen_api_key" not in state:
         state["qwen_api_key"] = os.getenv("QWEN_API_KEY", "")
+    if "gemini_api_key" not in state:
+        state["gemini_api_key"] = os.getenv("GEMINI_API_KEY", "")
     if "ui_tars_url" not in state or not state["ui_tars_url"]:
         state["ui_tars_url"] = os.getenv("UI_TARS_URL", state.get("ui_tars_url", ""))
     if "ui_tars_api_key" not in state or not state["ui_tars_api_key"]:
@@ -74,6 +78,8 @@ def setup_state(state):
             state["planner_api_key"] = state["anthropic_api_key"]
         elif state["planner_provider"] == "qwen":
             state["planner_api_key"] = state["qwen_api_key"]
+        elif state["planner_provider"] == "gemini":
+            state["planner_api_key"] = state["gemini_api_key"]
         else:
             state["planner_api_key"] = ""
 
@@ -265,11 +271,13 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
                 # Planner
                 planner_model = gr.Dropdown(
                     label="Planner Model",
-                    choices=["gpt-4o", 
-                             "gpt-4o-mini", 
-                             "qwen2-vl-max", 
-                             "qwen2-vl-2b (local)", 
-                             "qwen2-vl-7b (local)", 
+                    choices=["gpt-4o",
+                             "gpt-4o-mini",
+                             "gemini-1.5-flash",
+                             "gemini-1.5-pro",
+                             "qwen2-vl-max",
+                             "qwen2-vl-2b (local)",
+                             "qwen2-vl-7b (local)",
                              "qwen2-vl-2b (ssh)", 
                              "qwen2-vl-7b (ssh)",
                              "qwen2.5-vl-7b (ssh)", 
@@ -471,9 +479,23 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             actor_model_value = "ShowUI"
             actor_model_interactive = True
 
+        elif model_selection in ["gemini-1.5-flash", "gemini-1.5-pro"]:
+            provider_choices = ["gemini"]
+            provider_value = "gemini"
+            provider_interactive = False
+            api_key_interactive = True
+            api_key_placeholder = "gemini API key"
+            actor_model_choices = ["ShowUI", "UI-TARS"]
+            actor_model_value = "ShowUI"
+            actor_model_interactive = True
+            api_key_type = "password"
+
         elif model_selection == "claude-3-5-sonnet-20241022":
-            # Provider can be any of the current choices except 'openai'
-            provider_choices = [option.value for option in APIProvider if option.value != "openai"]
+            provider_choices = [
+                APIProvider.ANTHROPIC.value,
+                APIProvider.BEDROCK.value,
+                APIProvider.VERTEX.value,
+            ]
             provider_value = "anthropic"  # Set default to 'anthropic'
             state['actor_provider'] = "anthropic"
             provider_interactive = True
@@ -489,7 +511,8 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
 
         # Update the provider in state
         state["planner_api_provider"] = provider_value
-        
+        state["planner_provider"] = provider_value
+
         # Update api_key in state based on the provider
         if provider_value == "openai":
             state["api_key"] = state.get("openai_api_key", "")
@@ -497,9 +520,15 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             state["api_key"] = state.get("anthropic_api_key", "")
         elif provider_value == "qwen":
             state["api_key"] = state.get("qwen_api_key", "")
+        elif provider_value == "gemini":
+            state["api_key"] = state.get("gemini_api_key", "")
         elif provider_value == "local":
             state["api_key"] = ""
+        elif provider_value in ("bedrock", "vertex"):
+            state["api_key"] = ""
         # SSH的情况已经在上面处理过了，这里不需要重复处理
+
+        state["planner_api_key"] = state.get("api_key", "")
 
         provider_update = gr.update(
             choices=provider_choices,
@@ -528,20 +557,43 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
         state["actor_model"] = actor_model_selection
         logger.info(f"Actor model updated to: {state['actor_model']}")
 
-    def update_api_key_placeholder(provider_value, model_selection):
-        if model_selection == "claude-3-5-sonnet-20241022":
-            if provider_value == "anthropic":
-                return gr.update(placeholder="anthropic API key")
-            elif provider_value == "bedrock":
-                return gr.update(placeholder="bedrock API key")
-            elif provider_value == "vertex":
-                return gr.update(placeholder="vertex API key")
-            else:
-                return gr.update(placeholder="")
-        elif model_selection == "gpt-4o + ShowUI":
-            return gr.update(placeholder="openai API key")
-        else:
-            return gr.update(placeholder="")
+    def handle_planner_provider_change(provider_value, model_selection, state):
+        state["planner_provider"] = provider_value
+        state["planner_api_provider"] = provider_value
+
+        placeholder = ""
+        api_key_value = state.get("planner_api_key", "")
+        update_kwargs = {"type": "password"}
+
+        if provider_value == "anthropic":
+            placeholder = "anthropic API key"
+            api_key_value = state.get("anthropic_api_key", "")
+        elif provider_value == "bedrock":
+            placeholder = "bedrock API key"
+            api_key_value = ""
+        elif provider_value == "vertex":
+            placeholder = "vertex API key"
+            api_key_value = ""
+        elif provider_value == "openai":
+            placeholder = "openai API key"
+            api_key_value = state.get("openai_api_key", "")
+        elif provider_value == "qwen":
+            placeholder = "qwen API key"
+            api_key_value = state.get("qwen_api_key", "")
+        elif provider_value == "gemini":
+            placeholder = "gemini API key"
+            api_key_value = state.get("gemini_api_key", "")
+        elif provider_value == "local":
+            placeholder = "not required"
+            api_key_value = ""
+            update_kwargs["type"] = "password"
+        elif provider_value == "ssh":
+            placeholder = "ssh host and port (e.g. localhost:8000)"
+            update_kwargs["type"] = "text"
+        state["planner_api_key"] = api_key_value
+        state["api_key"] = api_key_value
+
+        return gr.update(value=api_key_value, placeholder=placeholder, **update_kwargs)
 
     def update_system_prompt_suffix(system_prompt_suffix, state):
         state["custom_system_prompt"] = system_prompt_suffix
@@ -629,7 +681,11 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
     chatbot = gr.Chatbot(label="Chatbot History", type="tuples", autoscroll=True, height=580, group_consecutive_messages=False)
     
     planner_model.change(fn=update_planner_model, inputs=[planner_model, state], outputs=[planner_api_provider, planner_api_key, actor_model])
-    planner_api_provider.change(fn=update_api_key_placeholder, inputs=[planner_api_provider, planner_model], outputs=planner_api_key)
+    planner_api_provider.change(
+        fn=handle_planner_provider_change,
+        inputs=[planner_api_provider, planner_model, state],
+        outputs=planner_api_key,
+    )
     actor_model.change(fn=update_actor_model, inputs=[actor_model, state], outputs=None)
 
     screen_selector.change(fn=update_selected_screen, inputs=[screen_selector, state], outputs=None)

--- a/computer_use_demo/gui_agent/llm_utils/gemini.py
+++ b/computer_use_demo/gui_agent/llm_utils/gemini.py
@@ -1,0 +1,107 @@
+import os
+import mimetypes
+from typing import Any
+
+import requests
+
+from computer_use_demo.gui_agent.llm_utils.llm_utils import encode_image, is_image_path
+
+
+def _build_image_part(image_path: str) -> dict[str, Any]:
+    mime_type, _ = mimetypes.guess_type(image_path)
+    if mime_type is None:
+        mime_type = "image/png"
+    return {
+        "inline_data": {
+            "mime_type": mime_type,
+            "data": encode_image(image_path),
+        }
+    }
+
+
+def run_gemini_interleaved(
+    messages: list | str,
+    system: str,
+    llm: str,
+    api_key: str,
+    max_tokens: int = 256,
+    temperature: float = 0,
+):
+    api_key = api_key or os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is not set")
+
+    if isinstance(messages, str):
+        iterable_messages: list[Any] = [messages]
+    else:
+        iterable_messages = messages
+
+    contents: list[dict[str, Any]] = []
+
+    for item in iterable_messages:
+        parts: list[dict[str, Any]] = []
+
+        if isinstance(item, dict):
+            role = item.get("role", "user")
+            for cnt in item.get("content", []):
+                if isinstance(cnt, str):
+                    if is_image_path(cnt):
+                        parts.append(_build_image_part(cnt))
+                    else:
+                        parts.append({"text": cnt})
+                elif isinstance(cnt, dict) and cnt.get("type") == "text":
+                    parts.append({"text": cnt.get("text", "")})
+            if parts:
+                contents.append({"role": role, "parts": parts})
+            continue
+
+        if isinstance(item, str) and is_image_path(item):
+            parts.append(_build_image_part(item))
+        else:
+            parts.append({"text": str(item)})
+
+        contents.append({"role": "user", "parts": parts})
+
+    payload: dict[str, Any] = {
+        "contents": contents,
+        "generationConfig": {
+            "temperature": temperature,
+            "maxOutputTokens": max_tokens,
+        },
+    }
+
+    if system:
+        payload["systemInstruction"] = {
+            "role": "system",
+            "parts": [{"text": system}],
+        }
+
+    response = requests.post(
+        f"https://generativelanguage.googleapis.com/v1beta/models/{llm}:generateContent",
+        params={"key": api_key},
+        json=payload,
+    )
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise ValueError(
+            f"Gemini API request failed: {response.text}"
+        ) from exc
+
+    data = response.json()
+
+    text_parts: list[str] = []
+    try:
+        candidate = data["candidates"][0]
+        for part in candidate.get("content", {}).get("parts", []):
+            if "text" in part:
+                text_parts.append(part["text"])
+    except (KeyError, IndexError, TypeError):
+        pass
+
+    text_response = "".join(text_parts) if text_parts else str(data)
+    usage = data.get("usageMetadata", {})
+    token_usage = usage.get("totalTokenCount") or usage.get("totalTokens") or 0
+
+    return text_response, int(token_usage)

--- a/computer_use_demo/gui_agent/planner/api_vlm_planner.py
+++ b/computer_use_demo/gui_agent/planner/api_vlm_planner.py
@@ -13,6 +13,7 @@ from anthropic.types.beta import BetaMessage, BetaTextBlock, BetaToolUseBlock, B
 from computer_use_demo.tools.screen_capture import get_screenshot
 from computer_use_demo.gui_agent.llm_utils.oai import run_oai_interleaved, run_ssh_llm_interleaved
 from computer_use_demo.gui_agent.llm_utils.qwen import run_qwen
+from computer_use_demo.gui_agent.llm_utils.gemini import run_gemini_interleaved
 from computer_use_demo.gui_agent.llm_utils.llm_utils import extract_data, encode_image
 from computer_use_demo.tools.colorful_text import colorful_text_showui, colorful_text_vlm
 
@@ -37,6 +38,10 @@ class APIVLMPlanner:
             self.model = "gpt-4o-mini"  # "gpt-4o-mini"
         elif model == "qwen2-vl-max":
             self.model = "qwen2-vl-max"
+        elif model == "gemini-1.5-flash":
+            self.model = "gemini-1.5-flash"
+        elif model == "gemini-1.5-pro":
+            self.model = "gemini-1.5-pro"
         elif model == "qwen2-vl-2b (ssh)":
             self.model = "Qwen2-VL-2B-Instruct"
         elif model == "qwen2-vl-7b (ssh)":
@@ -117,6 +122,17 @@ class APIVLMPlanner:
             print(f"qwen token usage: {token_usage}")
             self.total_token_usage += token_usage
             self.total_cost += (token_usage * 0.02 / 7.25 / 1000)  # 1USD=7.25CNY, https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api
+        elif self.model in ["gemini-1.5-flash", "gemini-1.5-pro"]:
+            vlm_response, token_usage = run_gemini_interleaved(
+                messages=planner_messages,
+                system=self.system_prompt,
+                llm=self.model,
+                api_key=self.api_key,
+                max_tokens=self.max_tokens,
+                temperature=0,
+            )
+            print(f"gemini token usage: {token_usage}")
+            self.total_token_usage += token_usage
         elif "Qwen" in self.model:
             # 从api_key中解析host和port
             try:

--- a/computer_use_demo/loop.py
+++ b/computer_use_demo/loop.py
@@ -23,6 +23,7 @@ class APIProvider(StrEnum):
     VERTEX = "vertex"
     OPENAI = "openai"
     QWEN = "qwen"
+    GEMINI = "gemini"
     SSH = "ssh"
 
 
@@ -32,14 +33,17 @@ PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
     APIProvider.VERTEX: "claude-3-5-sonnet-v2@20241022",
     APIProvider.OPENAI: "gpt-4o",
     APIProvider.QWEN: "qwen2vl",
+    APIProvider.GEMINI: "gemini-1.5-flash",
     APIProvider.SSH: "qwen2-vl-2b",
 }
 
 PLANNER_MODEL_CHOICES_MAPPING = {
     "claude-3-5-sonnet-20241022": "claude-3-5-sonnet-20241022",
     "gpt-4o": "gpt-4o",
-    "gpt-4o-mini": "gpt-4o-mini", 
+    "gpt-4o-mini": "gpt-4o-mini",
     "qwen2-vl-max": "qwen2-vl-max",
+    "gemini-1.5-flash": "gemini-1.5-flash",
+    "gemini-1.5-pro": "gemini-1.5-pro",
     "qwen2-vl-2b (local)": "qwen2-vl-2b-instruct",
     "qwen2-vl-7b (local)": "qwen2-vl-7b-instruct",
     "qwen2.5-vl-3b (local)": "qwen2.5-vl-3b-instruct",
@@ -107,7 +111,13 @@ def sampling_loop_sync(
 
         loop_mode = "unified"
 
-    elif planner_model in ["gpt-4o", "gpt-4o-mini", "qwen2-vl-max"]:
+    elif planner_model in [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "qwen2-vl-max",
+        "gemini-1.5-flash",
+        "gemini-1.5-pro",
+    ]:
         
         from computer_use_demo.gui_agent.planner.api_vlm_planner import APIVLMPlanner
 

--- a/docs/README_cn.md
+++ b/docs/README_cn.md
@@ -103,6 +103,7 @@ python app.py
 $env:ANTHROPIC_API_KEY="sk-xxxxx" (替换为您的密钥)
 $env:QWEN_API_KEY="sk-xxxxx"
 $env:OPENAI_API_KEY="sk-xxxxx"
+$env:GEMINI_API_KEY="sk-xxxxx"
 ```
 
 > 在 macOS/Linux 中，将上述命令中的 $env:ANTHROPIC_API_KEY 替换为 export ANTHROPIC_API_KEY 即可。


### PR DESCRIPTION
## Summary
- add Gemini API provider option alongside existing planner models and wire it through the Gradio UI state handling
- implement Gemini multimodal request helper and integrate it into the planner loop selections
- document the new GEMINI_API_KEY environment variable in both English and Chinese READMEs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e2a04343288325b96e6724f2a05ee1