### PR TITLE
Fix double offset handling for ShowUI absolute coordinates

### DIFF
--- a/computer_use_demo/executor/showui_executor.py
+++ b/computer_use_demo/executor/showui_executor.py
@@ -174,8 +174,8 @@ class ShowUIExecutor:
                         is_absolute_coordinate = True
 
                 if is_absolute_coordinate:
-                    converted_x = int(round(x_value + screen_left))
-                    converted_y = int(round(y_value + screen_top))
+                    converted_x = int(round(x_value - screen_left))
+                    converted_y = int(round(y_value - screen_top))
                 else:
                     converted_x = int(round(x_value * screen_width))
                     converted_y = int(round(y_value * screen_height))

--- a/tests/test_showui_executor.py
+++ b/tests/test_showui_executor.py
@@ -74,7 +74,7 @@ def test_parse_ui_tars_absolute_coordinates(executor):
     ])
     actions = executor._parse_showui_output(output)
 
-    assert actions[0]["coordinate"] == (250, 450)
+    assert actions[0]["coordinate"] == (50, 50)
 
 
 def test_parse_absolute_coordinates_without_source_flag(executor):
@@ -84,7 +84,7 @@ def test_parse_absolute_coordinates_without_source_flag(executor):
     actions = executor._parse_showui_output(output)
 
     assert actions[0]["action"] == "mouse_move"
-    assert actions[0]["coordinate"] == (1600, 1000)
+    assert actions[0]["coordinate"] == (1400, 600)
 
 
 def test_convert_ui_tars_action_includes_source_flag():


### PR DESCRIPTION
## Summary
- convert absolute ShowUI/UI-TARS coordinates to screen-relative pixels so `ComputerTool` offsets are not applied twice
- update executor tests to expect screen-relative values for absolute coordinates

## Testing
- pytest tests/test_showui_executor.py

------
https://chatgpt.com/codex/tasks/task_b_68e2a6f152948325870dd2cedcfbdeb4