### PR TITLE
Add interactive setup assistant and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,52 @@ The assistant can:
 - create `.env` or `api_keys.json` files with placeholders so you can add API keys later;
 - print the next steps (e.g., `python app.py`, default port `7860`).
 
-You can rerun the script at any time—every step is optional and idempotent.
+You can rerun the script at any time—every step is optional and idempotent. If you prefer manual setup, continue with Sections 3.1–3.4 below.
 
-### 3. Manual / Advanced Options (if you skipped the assistant)
+### 3. Manual Setup (if you skipped the assistant)
 
-- Install dependencies manually:
-    ```bash
-    pip install -r requirements.txt
+#### 3.1 Install Dependencies 🔧
+
+If you skipped the assistant, install the Python requirements yourself:
+
+```bash
+pip install -r requirements.txt
+```
+
+#### 3.2 (Optional) Get Prepared for **<span style="color:rgb(106, 158, 210)">S</span><span style="color:rgb(111, 163, 82)">h</span><span style="color:rgb(209, 100, 94)">o</span><span style="color:rgb(238, 171, 106)">w</span>UI** Local-Run
+
+1. Download all files of the ShowUI-2B model via the following command. Ensure the `ShowUI-2B` folder is under the `computer_use_ootb` folder.
+
+    ```python
+    python install_tools/install_showui.py
     ```
-- Download ShowUI-2B weights: `python install_tools/install_showui.py`
-- Download ShowUI-2B AWQ 4-bit (CUDA only): `python install_tools/install_showui-awq-4bit.py`
-- Follow [UI-TARS deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment) guides and sanity-check with `python install_tools/test_ui-tars_server.py`
-- Run a local Qwen planner server (advanced): `python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000`
+
+2. (Optional, CUDA only) Download the AWQ 4-bit weights:
+
+    ```python
+    python install_tools/install_showui-awq-4bit.py
+    ```
+
+3. Make sure to install the correct GPU version of PyTorch (CUDA, MPS, etc.) on your machine. See [install guide and verification](https://pytorch.org/get-started/locally/).
+
+4. Get API Keys for [GPT-4o](https://platform.openai.com/docs/quickstart) or [Qwen-VL](https://help.aliyun.com/zh/dashscope/developer-reference/acquisition-and-configuration-of-api-key). For mainland China users, Qwen API free trial for first 1 mil tokens is [available](https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api).
+
+#### 3.3 (Optional) Get Prepared for **UI-TARS** Local-Run
+
+1. Follow [Cloud Deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment) or [VLLM deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#local-deployment-vllm) guides to deploy your UI-TARS server.
+
+2. Test your UI-TARS sever with the script `.\install_tools\test_ui-tars_server.py`.
+
+#### 3.4 (Optional) Deploy the Qwen Planner on a Remote Server
+
+1. Clone this project on your SSH server.
+
+2. Start the planner bridge:
+
+    ```bash
+    python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000
+    ```
+
 ### 4. Start the Interface ▶️
 
 **Start the OOTB interface:**

--- a/README.md
+++ b/README.md
@@ -64,34 +64,34 @@ git clone https://github.com/showlab/computer_use_ootb.git
 cd computer_use_ootb
 ```
 
-### 2.1 Install Dependencies 🔧
+### 2. Use the Setup Assistant (Recommended) 🤖
+
+Run the interactive helper to check your environment, install dependencies, download optional local models, and generate API key templates:
+
 ```bash
-pip install -r requirements.txt
+python install_tools/setup_ootb.py
 ```
 
-### 2.2 (Optional) Get Prepared for **<span style="color:rgb(106, 158, 210)">S</span><span style="color:rgb(111, 163, 82)">h</span><span style="color:rgb(209, 100, 94)">o</span><span style="color:rgb(238, 171, 106)">w</span>UI** Local-Run
+The assistant can:
+- verify whether you're inside a Conda/venv environment;
+- install `requirements.txt` using your current Python interpreter;
+- optionally download ShowUI models (full precision or AWQ 4-bit) or review UI-TARS/Qwen deployment tips;
+- create `.env` or `api_keys.json` files with placeholders so you can add API keys later;
+- print the next steps (e.g., `python app.py`, default port `7860`).
 
-1. Download all files of the ShowUI-2B model via the following command. Ensure the `ShowUI-2B` folder is under the `computer_use_ootb` folder.
+You can rerun the script at any time—every step is optional and idempotent.
 
-    ```python
-    python install_tools/install_showui.py
+### 3. Manual / Advanced Options (if you skipped the assistant)
+
+- Install dependencies manually:
+    ```bash
+    pip install -r requirements.txt
     ```
-
-2. Make sure to install the correct GPU version of PyTorch (CUDA, MPS, etc.) on your machine. See [install guide and verification](https://pytorch.org/get-started/locally/).
-
-3. Get API Keys for [GPT-4o](https://platform.openai.com/docs/quickstart) or [Qwen-VL](https://help.aliyun.com/zh/dashscope/developer-reference/acquisition-and-configuration-of-api-key). For mainland China users, Qwen API free trial for first 1 mil tokens is [available](https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api).
-
-### 2.3 (Optional) Get Prepared for **UI-TARS** Local-Run
-
-1. Follow [Cloud Deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment) or [VLLM deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#local-deployment-vllm) guides to deploy your UI-TARS server.
-
-2. Test your UI-TARS sever with the script `.\install_tools\test_ui-tars_server.py`.
-
-### 2.4 (Optional) If you want to deploy Qwen model as planner on ssh server
-1. git clone this project on your ssh server
-
-2. python computer_use_demo/remote_inference.py
-### 3. Start the Interface ▶️
+- Download ShowUI-2B weights: `python install_tools/install_showui.py`
+- Download ShowUI-2B AWQ 4-bit (CUDA only): `python install_tools/install_showui-awq-4bit.py`
+- Follow [UI-TARS deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment) guides and sanity-check with `python install_tools/test_ui-tars_server.py`
+- Run a local Qwen planner server (advanced): `python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000`
+### 4. Start the Interface ▶️
 
 **Start the OOTB interface:**
 ```bash
@@ -114,7 +114,7 @@ If you successfully start the interface, you will see two URLs in the terminal:
 > On macOS/Linux, replace `$env:ANTHROPIC_API_KEY` with `export ANTHROPIC_API_KEY` in the above command. 
 
 
-### 4. Control Your Computer with Any Device can Access the Internet
+### 5. Control Your Computer with Any Device can Access the Internet
 - **Computer to be controlled**: The one installed software.
 - **Device Send Command**: The one opens the website.
   
@@ -131,6 +131,15 @@ python install_tools/install_showui-awq-4bit.py
 Then, enable the quantized setting in the 'ShowUI Advanced Settings' dropdown menu.
 
 Besides, we also provide a slider to quickly adjust the `max_pixel` parameter in the ShowUI model. This controls the visual input size of the model and greatly affects the memory and inference speed.
+
+### Troubleshooting Dependency & Permission Issues
+
+| Symptom | Likely Cause | Suggested Fix |
+| --- | --- | --- |
+| `pip` cannot write to site-packages | Missing admin rights / system Python | Activate a Conda env (`conda create -n ootb python=3.11`) and rerun `python install_tools/setup_ootb.py`. |
+| SSL or proxy errors when installing packages | Corporate network blocks PyPI | Configure your proxy in `pip.ini`/`.pip/pip.conf` or download wheels manually, then rerun the assistant. |
+| CUDA libraries not found while starting ShowUI | PyTorch GPU build missing | Reinstall PyTorch with the correct CUDA/MPS build: [install guide](https://pytorch.org/get-started/locally/). |
+| `PermissionError` when creating `.env` or model folders | Script executed from read-only directory | Move the repo to a writable location (e.g., `~/computer_use_ootb`) or rerun the script with elevated permissions. |
 
 ## 📊 GUI Agent Model Zoo
 

--- a/docs/README_cn.md
+++ b/docs/README_cn.md
@@ -78,18 +78,51 @@ python install_tools/setup_ootb.py
 - 创建 `.env` 或 `api_keys.json`，方便稍后填写密钥；
 - 输出下一步操作（例如 `python app.py`、默认端口 `7860`）。
 
-脚本可重复执行，所有步骤均为可选并具有幂等性。
+脚本可重复执行，所有步骤均为可选并具有幂等性。如果你倾向于手动配置，请继续阅读 3.1–3.4 小节。
 
-### 3. 手动/高级选项（如果跳过助手）
+### 3. 手动配置（如未使用助手）
 
-- 手动安装依赖：
+#### 3.1 手动安装依赖 🔧
+
+若未使用助手，请手动安装依赖：
+
+```
+pip install -r requirements.txt
+```
+
+#### 3.2 （可选）为 **<span style="color:rgb(106, 158, 210)">S</span><span style="color:rgb(111, 163, 82)">h</span><span style="color:rgb(209, 100, 94)">o</span><span style="color:rgb(238, 171, 106)">w</span>UI** 本地运行做准备
+
+1. 使用以下命令下载 ShowUI-2B 模型的所有文件。确保 `ShowUI-2B` 文件夹位于 `computer_use_ootb` 目录下。
+
     ```
-    pip install -r requirements.txt
+    python install_tools/install_showui.py
     ```
-- 下载 ShowUI-2B 权重：`python install_tools/install_showui.py`
-- 下载 ShowUI-2B AWQ 4-bit（仅限 CUDA）：`python install_tools/install_showui-awq-4bit.py`
-- 参考 [UI-TARS 部署指南](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment)，并使用 `python install_tools/test_ui-tars_server.py` 进行连通性检查
-- 运行本地 Qwen 规划器服务器（高级）：`python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000`
+
+2. （可选，仅限 CUDA）下载 ShowUI-2B 的 AWQ 4-bit 模型：
+
+    ```
+    python install_tools/install_showui-awq-4bit.py
+    ```
+
+3. 在您的机器上安装正确的 GPU 版 PyTorch（CUDA、MPS 等）。请参考 [安装指南与验证](https://pytorch.org/get-started/locally/)。
+
+4. 获取 [GPT-4o](https://platform.openai.com/docs/quickstart) 或 [Qwen-VL](https://help.aliyun.com/zh/dashscope/developer-reference/acquisition-and-configuration-of-api-key) 的 API Key。对于中国大陆用户，可享受 Qwen API 免费试用 100 万 token：[点击查看](https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api)。
+
+#### 3.3 （可选）为 **UI-TARS** 本地运行做准备
+
+1. 参考 [Cloud Deployment](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment) 或 [VLLM 部署](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#local-deployment-vllm) 指南部署 UI-TARS 服务。
+
+2. 通过脚本 `.\install_tools\test_ui-tars_server.py` 测试 UI-TARS 服务可用性。
+
+#### 3.4 （可选）在远程服务器部署 Qwen 规划器
+
+1. 在 SSH 服务器上克隆本项目。
+
+2. 启动规划器桥接：
+
+    ```
+    python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000
+    ```
 
 ### 4. 启动界面 ▶️
 

--- a/docs/README_cn.md
+++ b/docs/README_cn.md
@@ -63,26 +63,35 @@ git clone https://github.com/showlab/computer_use_ootb.git
 cd computer_use_ootb
 ```
 
-### 2.1 安装依赖 🔧
-```
-pip install -r dev-requirements.txt
-```
+### 2. 使用交互式安装助手（推荐）🤖
 
-### 2.2 （可选）为 **<span style="color:rgb(106, 158, 210)">S</span><span style="color:rgb(111, 163, 82)">h</span><span style="color:rgb(209, 100, 94)">o</span><span style="color:rgb(238, 171, 106)">w</span>UI** 本地运行做准备
+运行脚本即可检查 Conda/虚拟环境、安装依赖、下载本地模型，并生成 API Key 占位文件：
 
-1. 使用以下命令下载 ShowUI-2B 模型的所有文件。确保 ShowUI-2B 文件夹位于 computer_use_ootb 文件夹下。
-
-    
 ```
-python install_showui.py
+python install_tools/setup_ootb.py
 ```
 
+该助手可以：
+- 检测当前是否在 Conda/venv 中运行；
+- 使用当前 Python 解释器安装 `requirements.txt`；
+- 可选下载 ShowUI 全精度或 AWQ 4-bit 模型，或查看 UI-TARS / 本地 Qwen 配置提示；
+- 创建 `.env` 或 `api_keys.json`，方便稍后填写密钥；
+- 输出下一步操作（例如 `python app.py`、默认端口 `7860`）。
 
-2. 在您的机器上安装正确的 GPU 版 PyTorch（CUDA、MPS 等）。请参考 [安装指南与验证](https://pytorch.org/get-started/locally/)。
+脚本可重复执行，所有步骤均为可选并具有幂等性。
 
-3. 获取 [GPT-4o](https://platform.openai.com/docs/quickstart) 或 [Qwen-VL](https://help.aliyun.com/zh/dashscope/developer-reference/acquisition-and-configuration-of-api-key) 的 API Key。对于中国大陆用户，可享受 Qwen API 免费试用 100 万token：[点击查看](https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api)。
+### 3. 手动/高级选项（如果跳过助手）
 
-### 3. 启动界面 ▶️
+- 手动安装依赖：
+    ```
+    pip install -r requirements.txt
+    ```
+- 下载 ShowUI-2B 权重：`python install_tools/install_showui.py`
+- 下载 ShowUI-2B AWQ 4-bit（仅限 CUDA）：`python install_tools/install_showui-awq-4bit.py`
+- 参考 [UI-TARS 部署指南](https://github.com/bytedance/UI-TARS?tab=readme-ov-file#cloud-deployment)，并使用 `python install_tools/test_ui-tars_server.py` 进行连通性检查
+- 运行本地 Qwen 规划器服务器（高级）：`python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000`
+
+### 4. 启动界面 ▶️
 
 **启动 OOTB 界面：**
 ```
@@ -109,7 +118,7 @@ $env:GEMINI_API_KEY="sk-xxxxx"
 > 在 macOS/Linux 中，将上述命令中的 $env:ANTHROPIC_API_KEY 替换为 export ANTHROPIC_API_KEY 即可。
 
 
-### 4. 使用任意可访问网络的设备控制您的电脑
+### 5. 使用任意可访问网络的设备控制您的电脑
 - **待控制的电脑**：安装了上述软件的那台电脑。
 - **发送指令的设备**：打开网址的任意设备。
 
@@ -123,6 +132,16 @@ $env:GEMINI_API_KEY="sk-xxxxx"
   </figure>
 </div>
 
+
+
+### 依赖与权限问题排查表
+
+| 现象 | 可能原因 | 建议解决方案 |
+| --- | --- | --- |
+| `pip` 提示无写权限 | 使用系统 Python、无管理员权限 | 建议先创建 Conda 环境（如 `conda create -n ootb python=3.11`），再运行 `python install_tools/setup_ootb.py`。 |
+| 安装依赖出现 SSL/代理错误 | 公司或校园网络限制 PyPI | 在 `pip.ini`/`.pip/pip.conf` 中配置代理，或手动下载离线 whl 后重新执行助手。 |
+| 启动 ShowUI 时找不到 CUDA 库 | 未安装对应 CUDA 版本的 PyTorch | 参考 [官方安装指南](https://pytorch.org/get-started/locally/) 重新安装合适的 GPU 版 PyTorch。 |
+| 创建 `.env` 或模型目录时报 `PermissionError` | 仓库位于只读目录 | 将仓库移动到可写路径（如 `~/computer_use_ootb`），或在具有写权限的终端中重试。 |
 
 
 ## 🖥️ 支持的系统

--- a/install_tools/setup_ootb.py
+++ b/install_tools/setup_ootb.py
@@ -1,0 +1,303 @@
+"""Interactive setup helper for Computer Use OOTB.
+
+This script guides first-time users through the most common setup steps:
+
+* Detect the current Python environment (Conda/venv).
+* Install Python dependencies from ``requirements.txt``.
+* Optionally download local models (ShowUI full / AWQ) or review UI-TARS & Qwen tips.
+* Generate placeholder API key configuration files (``.env`` or ``api_keys.json``).
+* Summarise follow-up actions (startup command, ports, etc.).
+
+The goal is to make the onboarding process smoother while still being
+transparent about what happens at each step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from getpass import getpass
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIREMENTS_FILE = ROOT / "requirements.txt"
+
+
+def print_header(title: str) -> None:
+    line = "=" * len(title)
+    print(f"\n{line}\n{title}\n{line}")
+
+
+def detect_environment() -> Dict[str, str]:
+    """Inspect the current Python runtime and environment details."""
+
+    info = {
+        "python_executable": sys.executable,
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+    }
+
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        info["conda_env"] = os.environ.get("CONDA_DEFAULT_ENV", Path(conda_prefix).name)
+    else:
+        info["conda_env"] = "<not detected>"
+
+    if hasattr(sys, "real_prefix") or sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        info["virtualenv"] = sys.prefix
+    else:
+        info["virtualenv"] = "<not detected>"
+
+    info["pip_executable"] = shutil.which("pip") or "<not on PATH>"
+    info["conda_executable"] = shutil.which("conda") or "<not on PATH>"
+
+    return info
+
+
+def show_environment_info() -> None:
+    info = detect_environment()
+    print_header("Environment check")
+    for key, value in info.items():
+        print(f"- {key.replace('_', ' ').title()}: {value}")
+    print(
+        "\nTip: We recommend activating a Conda environment with Python >=3.11 before running this script."
+    )
+
+
+def prompt_yes_no(question: str, default: bool = True) -> bool:
+    suffix = " [Y/n]: " if default else " [y/N]: "
+    while True:
+        answer = input(question + suffix).strip().lower()
+        if not answer:
+            return default
+        if answer in {"y", "yes"}:
+            return True
+        if answer in {"n", "no"}:
+            return False
+        print("Please answer with 'y' or 'n'.")
+
+
+def prompt_multi_select(options: Sequence[Tuple[str, str]]) -> List[str]:
+    """Allow users to select multiple options by entering comma separated ids."""
+
+    print_header("Optional downloads & helpers")
+    print("Enter the numbers of the resources you'd like to prepare (comma-separated).\n"
+          "Press Enter to skip.")
+    for idx, (_, description) in enumerate(options, start=1):
+        print(f"  {idx}. {description}")
+
+    while True:
+        raw = input("Selection: ").strip()
+        if not raw:
+            return []
+
+        indices: List[str] = []
+        valid = True
+        for item in raw.split(','):
+            item = item.strip()
+            if not item:
+                continue
+            if not item.isdigit() or not (1 <= int(item) <= len(options)):
+                valid = False
+                break
+            indices.append(item)
+
+        if valid:
+            selected_ids = {options[int(i) - 1][0] for i in indices}
+            return sorted(selected_ids)
+
+        print("Invalid selection. Please enter valid option numbers (e.g. 1,3).");
+
+
+def run_subprocess(command: Sequence[str], description: str) -> bool:
+    """Run a subprocess and report success/failure."""
+
+    print(f"\n➡️ {description}\n   Command: {' '.join(command)}")
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"❌ Failed: {exc}")
+        return False
+    except FileNotFoundError as exc:
+        print(f"❌ Missing executable: {exc}")
+        return False
+
+    print("✅ Done")
+    return True
+
+
+def install_dependencies() -> bool:
+    if not REQUIREMENTS_FILE.exists():
+        print(f"requirements.txt not found at {REQUIREMENTS_FILE}. Skipping.")
+        return False
+
+    return run_subprocess(
+        [sys.executable, "-m", "pip", "install", "-r", str(REQUIREMENTS_FILE)],
+        "Installing Python dependencies",
+    )
+
+
+def prepare_showui(full_precision: bool) -> bool:
+    script = "install_showui.py" if full_precision else "install_showui-awq-4bit.py"
+    description = "Downloading ShowUI-2B model" if full_precision else "Downloading ShowUI-2B AWQ 4-bit model"
+    script_path = ROOT / "install_tools" / script
+    return run_subprocess([sys.executable, str(script_path)], description)
+
+
+def review_ui_tars() -> None:
+    print_header("UI-TARS setup tips")
+    print(
+        "- UI-TARS requires a separately deployed server (Cloud/VLLM).\n"
+        "- Follow the official guide: https://github.com/bytedance/UI-TARS.\n"
+        "- Once your server exposes an OpenAI-compatible endpoint, update the OOTB interface\n"
+        "  with the base URL and API key. Use install_tools/test_ui-tars_server.py to sanity check\n"
+        "  connectivity before launching the UI."
+    )
+
+
+def review_local_qwen() -> None:
+    print_header("Local Qwen planner tips")
+    print(
+        "- You can host a local Qwen planner via computer_use_demo/remote_inference.py.\n"
+        "- Recommended hardware: >=24GB RAM, CUDA GPU with >=12GB VRAM for 7B models.\n"
+        "- Start the server: python computer_use_demo/remote_inference.py --host 0.0.0.0 --port 8000\n"
+        "- Configure OOTB to point to http://<server-ip>:8000/v1 when selecting the planner."
+    )
+
+
+API_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "QWEN_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+]
+
+
+def collect_api_keys() -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    if not prompt_yes_no("Would you like to enter API keys now?", default=False):
+        return {key: "" for key in API_KEYS}
+
+    print("Press Enter to skip any key you don't have yet. Input will be hidden.")
+    for key in API_KEYS:
+        values[key] = getpass(f"{key}: ")
+    return values
+
+
+def write_env_file(values: Dict[str, str]) -> Path:
+    path = ROOT / ".env"
+    lines = ["# API keys for Computer Use OOTB"]
+    lines.extend(f"{key}={value}" for key, value in values.items())
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def write_json_file(values: Dict[str, str]) -> Path:
+    path = ROOT / "api_keys.json"
+    path.write_text(json.dumps(values, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def configure_api_keys() -> Path | None:
+    print_header("API key configuration")
+    if not prompt_yes_no("Generate API key template now?", default=True):
+        return None
+
+    options = [
+        ("env", ".env (dotenv format)"),
+        ("json", "api_keys.json (JSON format)"),
+    ]
+    for idx, (_, label) in enumerate(options, start=1):
+        print(f"  {idx}. {label}")
+
+    choice = None
+    while choice is None:
+        raw = input("Choose file format [1/2]: ").strip() or "1"
+        if raw in {"1", "2"}:
+            choice = options[int(raw) - 1][0]
+        else:
+            print("Please enter 1 or 2.")
+
+    values = collect_api_keys()
+    if choice == "env":
+        path = write_env_file(values)
+    else:
+        path = write_json_file(values)
+
+    print(f"Saved API key placeholders to {path}")
+    return path
+
+
+def main() -> None:
+    print_header("Computer Use OOTB setup")
+    show_environment_info()
+
+    performed_steps: List[str] = []
+    follow_up: List[str] = []
+
+    if prompt_yes_no("Install dependencies from requirements.txt?", default=True):
+        if install_dependencies():
+            performed_steps.append("Installed Python dependencies")
+        else:
+            follow_up.append("Check pip/permission issues if dependencies were not installed.")
+
+    model_options = [
+        ("showui_full", "Download ShowUI-2B (full precision)"),
+        ("showui_awq", "Download ShowUI-2B AWQ 4-bit (CUDA only)"),
+        ("ui_tars", "Review UI-TARS deployment checklist"),
+        ("qwen_local", "Review local Qwen planner tips"),
+    ]
+
+    selections = prompt_multi_select(model_options)
+    for selection in selections:
+        if selection == "showui_full":
+            if prepare_showui(full_precision=True):
+                performed_steps.append("Prepared ShowUI-2B model")
+                follow_up.append("Enable ShowUI in the interface and point to the downloaded weights.")
+        elif selection == "showui_awq":
+            if prepare_showui(full_precision=False):
+                performed_steps.append("Prepared ShowUI-2B AWQ model")
+                follow_up.append("Select the AWQ quantized option in ShowUI advanced settings (CUDA only).")
+        elif selection == "ui_tars":
+            review_ui_tars()
+            performed_steps.append("Reviewed UI-TARS setup guidance")
+        elif selection == "qwen_local":
+            review_local_qwen()
+            performed_steps.append("Reviewed local Qwen planner guidance")
+
+    api_file = configure_api_keys()
+    if api_file:
+        performed_steps.append(f"Created API key template at {api_file.relative_to(ROOT)}")
+        follow_up.append("Populate the generated file with your actual API keys before launching.")
+
+    follow_up.extend([
+        "Launch the interface: python app.py",
+        "Default UI port: http://127.0.0.1:7860",
+        "Remote (gradio) URL will be printed on launch for secure sharing.",
+    ])
+
+    print_header("Summary")
+    if performed_steps:
+        print("Completed steps:")
+        for item in performed_steps:
+            print(f"  - {item}")
+    else:
+        print("No automated steps were executed.")
+
+    print("\nNext actions:")
+    for item in follow_up:
+        print(f"  • {item}")
+
+    print("\nSetup assistant finished. Happy hacking! ✨")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nSetup interrupted by user.")


### PR DESCRIPTION
## Summary
- add an interactive `install_tools/setup_ootb.py` helper that installs dependencies, downloads models, and scaffolds API key templates
- document the new setup assistant in the English and Chinese Getting Started guides and clarify optional manual steps
- add dependency and permission troubleshooting tables to both READMEs

## Testing
- python -m compileall install_tools/setup_ootb.py

------
https://chatgpt.com/codex/tasks/task_b_68e327482520832580c118824dff4453